### PR TITLE
refactor: website item page builder code to support v14 changes

### DIFF
--- a/kersten_erpnext/templates/generators/item/item.html
+++ b/kersten_erpnext/templates/generators/item/item.html
@@ -30,14 +30,17 @@
 {% block base_scripts %}
 <!-- js should be loaded in body! -->
 <script type="text/javascript" src="/assets/frappe/js/lib/jquery/jquery.min.js"></script>
-<script type="text/javascript" src="/assets/js/frappe-web.min.js"></script>
-<script type="text/javascript" src="/assets/js/control.min.js"></script>
-<script type="text/javascript" src="/assets/js/dialog.min.js"></script>
-<script type="text/javascript" src="/assets/js/bootstrap-4-web.min.js"></script>
+{{ include_script("frappe-web.bundle.js") }}
+{{ include_script("controls.bundle.js") }}
+{{ include_script("dialog.bundle.js") }}
 {% endblock %}
 
 {% block script %}
-	{%- for script in page_builder_scripts -%}
-	<script>{{ script }}</script>
+	{%- for web_template, scripts in (page_builder_scripts or {}).items() -%}
+		{%- if scripts -%}
+			{%- for script in scripts -%}
+				<script data-web-template="{{ web_template }}">{{ script }}</script>
+			{%- endfor -%}
+		{%- endif -%}
 	{%- endfor -%}
 {% endblock %}


### PR DESCRIPTION
Issue: The section with Tabs was not working since `get_web_blocks_html` gives different output in frappe v14, also the way we include script is changed because of esbuild